### PR TITLE
feat: support VirtualTable minColumnWidth

### DIFF
--- a/packages/cra-template-seasoning-pc-admin/template/src/components/pageTable/virtual_table.tsx
+++ b/packages/cra-template-seasoning-pc-admin/template/src/components/pageTable/virtual_table.tsx
@@ -7,99 +7,101 @@ import styles from './style.module.less';
 
 export type TVirtualTableProps = TableProps<any> & {
   tableWidth?: number;
+  minColumnWidth?: number; // 最小列宽，当 width 未指定时选择
 };
 
 /**
  * 虚拟滚动表格
  */
-export const VirtualTable = combine<TVirtualTableProps>(({ stores, tableWidth = 0, columns = [], ...props }) => {
-  const { componentSize = 'large' } = stores.layout.setting;
-  const gridRef = useRef<VariableSizeGrid>(null);
-  const { x = 0, y = 0 } = props.scroll || {};
+export const VirtualTable = combine<TVirtualTableProps>(
+  ({ stores, tableWidth = 0, minColumnWidth = 100, columns = [], ...props }) => {
+    const { componentSize = 'large' } = stores.layout.setting;
+    const gridRef = useRef<VariableSizeGrid>(null);
+    const { x = 0, y = 0 } = props.scroll || {};
 
-  useEffect(() => {
-    gridRef.current?.resetAfterIndices({
-      rowIndex: 0,
-      columnIndex: 0,
-      shouldForceUpdate: false,
-    });
-  }, [tableWidth]);
-
-  // 给剩余的列分配宽度，并过滤 fixed
-  const mergedColumns = useMemo(() => {
-    let laveWidth = +x;
-    const { length } = columns.filter(({ width }) => {
-      if (width) laveWidth -= +width;
-      return !width;
-    });
-    const width = Math.floor(laveWidth / length);
-    let mergedColumns = columns.map(({ fixed, ...column }) => (column.width ? column : { ...column, width }));
-
-    // 实际宽度大于滚动宽度时，放大列宽
-    if (tableWidth > x) {
-      const scale = tableWidth / +x;
-      mergedColumns = mergedColumns.map(({ width, ...column }) => {
-        return { ...column, width: Math.floor(+width! * scale) };
+    useEffect(() => {
+      gridRef.current?.resetAfterIndices({
+        rowIndex: 0,
+        columnIndex: 0,
+        shouldForceUpdate: false,
       });
-    }
-    return mergedColumns;
-  }, [x, tableWidth]);
+    }, [tableWidth]);
 
-  const [connectObject] = useState(() => {
-    const obj = {};
-    Object.defineProperty(obj, 'scrollLeft', {
-      get: () => null,
-      set: (scrollLeft) => {
-        if (gridRef.current) {
-          gridRef.current!.scrollTo({
-            scrollLeft,
-          } as any);
-        }
-      },
+    // 给剩余的列分配宽度，若分配的宽度小于最小列宽，将启用最小列宽，并过滤 fixed
+    const mergedColumns = useMemo(() => {
+      const { length } = columns!.filter(({ width }) => !width);
+      const tmpWidth = length === 0 ? 0 : Math.floor((tableWidth - +x) / length);
+      const width = tmpWidth < minColumnWidth ? minColumnWidth : tmpWidth;
+      let mergedColumns = columns.map(({ fixed, ...column }) => (column.width ? column : { ...column, width }));
+
+      // 实际宽度大于滚动宽度时，放大列宽
+      const columnsWidth = width * length + +x;
+      if (tableWidth > columnsWidth) {
+        const scale = tableWidth / columnsWidth;
+        mergedColumns = mergedColumns.map(({ width, ...column }) => {
+          return { ...column, width: Math.floor(+width! * scale) };
+        });
+      }
+
+      return mergedColumns;
+    }, [x, tableWidth]);
+
+    const [connectObject] = useState(() => {
+      const obj = {};
+      Object.defineProperty(obj, 'scrollLeft', {
+        get: () => null,
+        set: (scrollLeft) => {
+          if (gridRef.current) {
+            gridRef.current!.scrollTo({
+              scrollLeft,
+            } as any);
+          }
+        },
+      });
+      return obj;
     });
-    return obj;
-  });
 
-  const renderVirtualList = (rawData: any, { ref, onScroll }: any) => {
-    ref.current = connectObject;
+    const renderVirtualList = (rawData: any, { ref, onScroll }: any) => {
+      ref.current = connectObject;
+      return (
+        <VariableSizeGrid
+          ref={gridRef}
+          className="virtual-grid"
+          height={+y}
+          rowCount={rawData.length}
+          columnCount={mergedColumns.length}
+          rowHeight={() => rowHeights[componentSize]}
+          width={tableWidth}
+          onScroll={({ scrollLeft }) => onScroll({ scrollLeft })}
+          columnWidth={(index) => +mergedColumns[index].width!}
+        >
+          {({ columnIndex, rowIndex, style }) => {
+            const { dataIndex, render } = mergedColumns[columnIndex] as any;
+            const data = rawData[rowIndex];
+            const column = data['' + dataIndex];
+
+            return (
+              <div style={{ padding: columnPadding[componentSize], ...style }} className={styles.virtualColumn}>
+                {render?.(column ?? data, data, rowIndex) || column}
+              </div>
+            );
+          }}
+        </VariableSizeGrid>
+      );
+    };
+
     return (
-      <VariableSizeGrid
-        ref={gridRef}
-        className="virtual-grid"
-        height={+y}
-        rowCount={rawData.length}
-        columnCount={mergedColumns.length}
-        rowHeight={() => rowHeights[componentSize]}
-        width={tableWidth}
-        onScroll={({ scrollLeft }) => onScroll({ scrollLeft })}
-        columnWidth={(index) => +mergedColumns[index].width!}
-      >
-        {({ columnIndex, rowIndex, style }) => {
-          const { dataIndex, render } = mergedColumns[columnIndex] as any;
-          const data = rawData[rowIndex];
-          const column = data['' + dataIndex];
-
-          return (
-            <div style={{ padding: columnPadding[componentSize], ...style }} className={styles.virtualColumn}>
-              {render?.(column ?? data, data, rowIndex) || column}
-            </div>
-          );
+      <Table
+        {...props}
+        rowSelection={undefined}
+        columns={mergedColumns}
+        components={{
+          body: renderVirtualList,
         }}
-      </VariableSizeGrid>
+      />
     );
-  };
-
-  return (
-    <Table
-      {...props}
-      rowSelection={undefined}
-      columns={mergedColumns}
-      components={{
-        body: renderVirtualList,
-      }}
-    />
-  );
-});
+  }
+);
 
 const rowHeights: any = { large: 54, middle: 46, small: 38 };
 

--- a/src/pc-admin/template/src/components/pageTable/virtual_table.tsx
+++ b/src/pc-admin/template/src/components/pageTable/virtual_table.tsx
@@ -7,99 +7,101 @@ import styles from './style.module.less';
 
 export type TVirtualTableProps = TableProps<any> & {
   tableWidth?: number;
+  minColumnWidth?: number; // 最小列宽，当 width 未指定时选择
 };
 
 /**
  * 虚拟滚动表格
  */
-export const VirtualTable = combine<TVirtualTableProps>(({ stores, tableWidth = 0, columns = [], ...props }) => {
-  const { componentSize = 'large' } = stores.layout.setting;
-  const gridRef = useRef<VariableSizeGrid>(null);
-  const { x = 0, y = 0 } = props.scroll || {};
+export const VirtualTable = combine<TVirtualTableProps>(
+  ({ stores, tableWidth = 0, minColumnWidth = 100, columns = [], ...props }) => {
+    const { componentSize = 'large' } = stores.layout.setting;
+    const gridRef = useRef<VariableSizeGrid>(null);
+    const { x = 0, y = 0 } = props.scroll || {};
 
-  useEffect(() => {
-    gridRef.current?.resetAfterIndices({
-      rowIndex: 0,
-      columnIndex: 0,
-      shouldForceUpdate: false,
-    });
-  }, [tableWidth]);
-
-  // 给剩余的列分配宽度，并过滤 fixed
-  const mergedColumns = useMemo(() => {
-    let laveWidth = +x;
-    const { length } = columns.filter(({ width }) => {
-      if (width) laveWidth -= +width;
-      return !width;
-    });
-    const width = Math.floor(laveWidth / length);
-    let mergedColumns = columns.map(({ fixed, ...column }) => (column.width ? column : { ...column, width }));
-
-    // 实际宽度大于滚动宽度时，放大列宽
-    if (tableWidth > x) {
-      const scale = tableWidth / +x;
-      mergedColumns = mergedColumns.map(({ width, ...column }) => {
-        return { ...column, width: Math.floor(+width! * scale) };
+    useEffect(() => {
+      gridRef.current?.resetAfterIndices({
+        rowIndex: 0,
+        columnIndex: 0,
+        shouldForceUpdate: false,
       });
-    }
-    return mergedColumns;
-  }, [x, tableWidth]);
+    }, [tableWidth]);
 
-  const [connectObject] = useState(() => {
-    const obj = {};
-    Object.defineProperty(obj, 'scrollLeft', {
-      get: () => null,
-      set: (scrollLeft) => {
-        if (gridRef.current) {
-          gridRef.current!.scrollTo({
-            scrollLeft,
-          } as any);
-        }
-      },
+    // 给剩余的列分配宽度，若分配的宽度小于最小列宽，将启用最小列宽，并过滤 fixed
+    const mergedColumns = useMemo(() => {
+      const { length } = columns!.filter(({ width }) => !width);
+      const tmpWidth = length === 0 ? 0 : Math.floor((tableWidth - +x) / length);
+      const width = tmpWidth < minColumnWidth ? minColumnWidth : tmpWidth;
+      let mergedColumns = columns.map(({ fixed, ...column }) => (column.width ? column : { ...column, width }));
+
+      // 实际宽度大于滚动宽度时，放大列宽
+      const columnsWidth = width * length + +x;
+      if (tableWidth > columnsWidth) {
+        const scale = tableWidth / columnsWidth;
+        mergedColumns = mergedColumns.map(({ width, ...column }) => {
+          return { ...column, width: Math.floor(+width! * scale) };
+        });
+      }
+
+      return mergedColumns;
+    }, [x, tableWidth]);
+
+    const [connectObject] = useState(() => {
+      const obj = {};
+      Object.defineProperty(obj, 'scrollLeft', {
+        get: () => null,
+        set: (scrollLeft) => {
+          if (gridRef.current) {
+            gridRef.current!.scrollTo({
+              scrollLeft,
+            } as any);
+          }
+        },
+      });
+      return obj;
     });
-    return obj;
-  });
 
-  const renderVirtualList = (rawData: any, { ref, onScroll }: any) => {
-    ref.current = connectObject;
+    const renderVirtualList = (rawData: any, { ref, onScroll }: any) => {
+      ref.current = connectObject;
+      return (
+        <VariableSizeGrid
+          ref={gridRef}
+          className="virtual-grid"
+          height={+y}
+          rowCount={rawData.length}
+          columnCount={mergedColumns.length}
+          rowHeight={() => rowHeights[componentSize]}
+          width={tableWidth}
+          onScroll={({ scrollLeft }) => onScroll({ scrollLeft })}
+          columnWidth={(index) => +mergedColumns[index].width!}
+        >
+          {({ columnIndex, rowIndex, style }) => {
+            const { dataIndex, render } = mergedColumns[columnIndex] as any;
+            const data = rawData[rowIndex];
+            const column = data['' + dataIndex];
+
+            return (
+              <div style={{ padding: columnPadding[componentSize], ...style }} className={styles.virtualColumn}>
+                {render?.(column ?? data, data, rowIndex) || column}
+              </div>
+            );
+          }}
+        </VariableSizeGrid>
+      );
+    };
+
     return (
-      <VariableSizeGrid
-        ref={gridRef}
-        className="virtual-grid"
-        height={+y}
-        rowCount={rawData.length}
-        columnCount={mergedColumns.length}
-        rowHeight={() => rowHeights[componentSize]}
-        width={tableWidth}
-        onScroll={({ scrollLeft }) => onScroll({ scrollLeft })}
-        columnWidth={(index) => +mergedColumns[index].width!}
-      >
-        {({ columnIndex, rowIndex, style }) => {
-          const { dataIndex, render } = mergedColumns[columnIndex] as any;
-          const data = rawData[rowIndex];
-          const column = data['' + dataIndex];
-
-          return (
-            <div style={{ padding: columnPadding[componentSize], ...style }} className={styles.virtualColumn}>
-              {render?.(column ?? data, data, rowIndex) || column}
-            </div>
-          );
+      <Table
+        {...props}
+        rowSelection={undefined}
+        columns={mergedColumns}
+        components={{
+          body: renderVirtualList,
         }}
-      </VariableSizeGrid>
+      />
     );
-  };
-
-  return (
-    <Table
-      {...props}
-      rowSelection={undefined}
-      columns={mergedColumns}
-      components={{
-        body: renderVirtualList,
-      }}
-    />
-  );
-});
+  }
+);
 
 const rowHeights: any = { large: 54, middle: 46, small: 38 };
 


### PR DESCRIPTION
在启用虚拟表格时，如果没有指定列宽，会被设置为宽度为0。因此增加了一个 minColumnWidth 的参数，当进行表格剩余宽度分配时，如果最后分配下来的宽度小于 minColumnWidth 则将启用 minColumnWidth  作为列宽。